### PR TITLE
KBNZ-3197 Remove safe navigation operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Changes 
 
-## Changes 2.8.4
+### Changes in 2.8.5
+* Changes
+
+    * Remove safe navigation operator from changes made in 2.8.3 to make gem compatible with Ruby versions < 2.3
+
+### Changes in 2.8.4
 * Bug
 
     * Connection to Lets Encrypt secured server fails

--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -450,7 +450,7 @@ class HTTPClient
     self.proxy = proxy if proxy
     keep_webmock_compat
     instance_eval(&block) if block
-    @session_manager&.ssl_config&.set_default_paths
+    @session_manager.ssl_config.set_default_paths
   end
 
   # webmock 1.6.2 depends on HTTP::Message#body.content to work.


### PR DESCRIPTION
### Problem
Usage of the safe navigation operator (`&.`) stops this gem from working on our repos that are stuck on Ruby versions before 2.3.0. It is also probably not necessary to use it since the line `@session_manager.ssl_config = @ssl_config = SSLConfig.new(self)` before it should ensure that the method is available.

### Solution
Remove the safe navigation operator.

### Notes
None.